### PR TITLE
HH-257974 use additional response code while webhooks checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ server/plugin/manifest.go
 
 # VS Code
 .vscode
+
+dev/.env


### PR DESCRIPTION
Поправил ошибку, которая возникала при попытке проверить настроен ли вебхук, если пользователь подписывался на репу или организацию. Подписка при этом происходила, но пользователя смущала ошибка в ответ

ДО
<img width="1288" alt="Снимок экрана 2025-05-15 в 13 27 07" src="https://github.com/user-attachments/assets/54f2fccc-ae3a-4870-be3f-4291934e5e9e" />

ПОСЛЕ
<img width="970" alt="Снимок экрана 2025-05-15 в 13 41 22" src="https://github.com/user-attachments/assets/dfc04da3-795b-46c8-8e6c-6f072a3eff54" />
