### PR TITLE
HH-258253 disable team review notifications

### DIFF
--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -220,17 +220,19 @@ func (p *FPullRequestReview) GetContent() string {
 }
 
 type FPullRequest struct {
-	ID        *int      `json:"id,omitempty"`
-	Labels    []*FLabel `json:"labels,omitempty"`
-	User      *FUser    `json:"user,omitempty"`
-	Number    *int      `json:"number,omitempty"`
-	Draft     *bool     `json:"draft,omitempty"`
-	Merged    *bool     `json:"merged,omitempty"`
-	Title     *string   `json:"title,omitempty"`
-	HTMLURL   *string   `json:"html_url,omitempty"`
-	Assignee  *FUser    `json:"assignee,omitempty"`
-	Assignees []*FUser  `json:"assignees,omitempty"`
-	Body      *string   `json:"body,omitempty"`
+	ID                      *int      `json:"id,omitempty"`
+	Labels                  []*FLabel `json:"labels,omitempty"`
+	User                    *FUser    `json:"user,omitempty"`
+	Number                  *int      `json:"number,omitempty"`
+	Draft                   *bool     `json:"draft,omitempty"`
+	Merged                  *bool     `json:"merged,omitempty"`
+	Title                   *string   `json:"title,omitempty"`
+	HTMLURL                 *string   `json:"html_url,omitempty"`
+	Assignee                *FUser    `json:"assignee,omitempty"`
+	Assignees               []*FUser  `json:"assignees,omitempty"`
+	Body                    *string   `json:"body,omitempty"`
+	RequestedReviewers      []*FUser  `json:"requested_reviewers,omitempty"`
+	RequestedReviewersTeams []*FTeam  `json:"requested_reviewers_teams,omitempty"`
 }
 
 func (p *FPullRequestEvent) GetPullRequest() *FPullRequest {
@@ -284,6 +286,11 @@ type FLabel struct {
 }
 
 type FTaskStep = github.TaskStep
+
+type FTeam struct {
+	ID   *int64  `json:"id,omitempty"`
+	Name *string `json:"name,omitempty"`
+}
 
 func (p *Plugin) writeJSON(w http.ResponseWriter, v interface{}) {
 	b, err := json.Marshal(v)

--- a/server/plugin/command.go
+++ b/server/plugin/command.go
@@ -680,8 +680,11 @@ func (p *Plugin) handleSettings(_ *plugin.Context, _ *model.CommandArgs, paramet
 				switch parsedFlag {
 				case settingExclude:
 					{
-						if len(parameters) != 4 {
+						if len(parameters) < 4 {
 							return "Must set excluded repos"
+						}
+						if len(parameters) > 4 {
+							return "Invalid format. Repository names must be comma-separated in a single argument"
 						}
 						repos := strings.Split(parameters[3], ",")
 						for i := range repos {
@@ -698,6 +701,8 @@ func (p *Plugin) handleSettings(_ *plugin.Context, _ *model.CommandArgs, paramet
 		case settingOff:
 			userInfo.Settings.ExcludeTeamReviewNotifications = []string{}
 			userInfo.Settings.DisableTeamNotifications = true
+		default:
+			return "Invalid setting. Use `on` or `off`."
 		}
 	default:
 		return "Unknown setting " + setting

--- a/server/plugin/command.go
+++ b/server/plugin/command.go
@@ -667,6 +667,38 @@ func (p *Plugin) handleSettings(_ *plugin.Context, _ *model.CommandArgs, paramet
 		default:
 			return "Invalid value. Accepted values are: \"on\" or \"off\" or \"on-change\" ."
 		}
+	case settingTeamNotifications:
+		switch settingValue {
+		case settingOn:
+			userInfo.Settings.DisableTeamNotifications = false
+			if len(parameters) > 2 {
+				flag := parameters[2]
+				if !isFlag(flag) {
+					return "Please use the correct format for flags: --<name> <value>"
+				}
+				parsedFlag := parseFlag(flag)
+				switch parsedFlag {
+				case settingExclude:
+					{
+						if len(parameters) != 4 {
+							return "Must set excluded repos"
+						}
+						repos := strings.Split(parameters[3], ",")
+						for i := range repos {
+							repos[i] = strings.TrimSpace(repos[i])
+						}
+						userInfo.Settings.ExcludeTeamReviewNotifications = repos
+					}
+				default:
+					return "Unknown flag"
+				}
+			} else {
+				userInfo.Settings.ExcludeTeamReviewNotifications = []string{}
+			}
+		case settingOff:
+			userInfo.Settings.ExcludeTeamReviewNotifications = []string{}
+			userInfo.Settings.DisableTeamNotifications = true
+		}
 	default:
 		return "Unknown setting " + setting
 	}
@@ -1006,6 +1038,18 @@ func getAutocompleteData(config *Configuration) *model.AutocompleteData {
 	}}
 	remainderNotifications.AddStaticListArgument("", true, settingValue)
 	settings.AddCommand(remainderNotifications)
+
+	excludeTeamNotifications := model.NewAutocompleteData(settingTeamNotifications, "", "Configure team review notifications")
+	settingValue = []model.AutocompleteListItem{{
+		HelpText: "Enable team review notifications (you will be notified when your team is requested for review)",
+		Item:     "on",
+	}, {
+		HelpText: "Disable team review notifications (you will not be notified when your team is requested for review)",
+		Item:     "off",
+	}}
+	excludeTeamNotifications.AddStaticListArgument("", true, settingValue)
+	excludeTeamNotifications.AddNamedTextArgument(settingExclude, "Exclude specific repositories", "Comma-separated list of repository names to exclude from team notifications (e.g. 'repo1,repo2'). Only works when team-review-notifications is turned on", `/[^,-\s]+(,[^,-\s]+)*/`, false)
+	settings.AddCommand(excludeTeamNotifications)
 
 	forgejo.AddCommand(settings)
 

--- a/server/plugin/command_test.go
+++ b/server/plugin/command_test.go
@@ -329,9 +329,6 @@ func TestExecuteCommand(t *testing.T) {
 				assert.Contains(t, post.Message, tt.expectedMsg)
 			}).Once().Return(&model.Post{})
 
-			// Allow LogWarn calls for decryption errors
-			currentTestAPI.On("LogWarn", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-
 			p := getPluginTest(currentTestAPI, mockKvStore)
 
 			_, err := p.ExecuteCommand(&plugin.Context{}, tt.commandArgs)

--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -37,12 +37,14 @@ const (
 	wsEventRefresh      = "refresh"
 	wsEventCreateIssue  = "createIssue"
 
-	settingButtonsTeam   = "team"
-	settingNotifications = "notifications"
-	settingReminders     = "reminders"
-	settingOn            = "on"
-	settingOff           = "off"
-	settingOnChange      = "on-change"
+	settingButtonsTeam       = "team"
+	settingNotifications     = "notifications"
+	settingTeamNotifications = "team-review-notifications"
+	settingReminders         = "reminders"
+	settingOn                = "on"
+	settingOff               = "off"
+	settingOnChange          = "on-change"
+	settingExclude           = "exclude"
 
 	dailySummary = "_dailySummary"
 )
@@ -548,10 +550,12 @@ type ForgejoUserInfo struct {
 }
 
 type UserSettings struct {
-	SidebarButtons        string `json:"sidebar_buttons"`
-	DailyReminder         bool   `json:"daily_reminder"`
-	DailyReminderOnChange bool   `json:"daily_reminder_on_change"`
-	Notifications         bool   `json:"notifications"`
+	SidebarButtons                 string   `json:"sidebar_buttons"`
+	DailyReminder                  bool     `json:"daily_reminder"`
+	DailyReminderOnChange          bool     `json:"daily_reminder_on_change"`
+	Notifications                  bool     `json:"notifications"`
+	DisableTeamNotifications       bool     `json:"disable_team_review_notifications"`
+	ExcludeTeamReviewNotifications []string `json:"exclude_team_review_notifications"`
 }
 
 func (p *Plugin) storeGitHubUserInfo(info *ForgejoUserInfo) error {

--- a/server/plugin/template.go
+++ b/server/plugin/template.go
@@ -482,6 +482,10 @@ Assignees: {{range $i, $el := .Assignees -}} {{- if $i}}, {{end}}{{template "FUs
 		"* `/forgejo settings [setting] [value]` - Update your user settings\n" +
 		"  * `setting` can be `notifications` or `reminders`\n" +
 		"  * `value` can be `on` or `off`\n" +
+		"  * `setting` can be `team-review-notifications`\n" +
+		"    * `value` can be `on` or `off`\n" +
+		"    * When `on`, you can use `--exclude` flag to specify repositories to exclude from team notifications\n" +
+		"    * Example: `/forgejo settings team-review-notifications on --exclude repo1,repo2`\n" +
 		"* `/forgejo mute` - Managed muted Forgejo users. You'll not receive notifications for comments in your PRs and issues from those users.\n" +
 		"  * `/forgejo mute list` - list your muted Forgejo users\n" +
 		"  * `/forgejo mute add [username]` - add a Forgejo user to your muted list\n" +

--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -1280,29 +1280,29 @@ func (p *Plugin) ignoreRequestedReview(event *FPullRequestEvent, requestedUserID
 		return false
 	}
 	reviewers := event.PullRequest.RequestedReviewers
-	if len(reviewers) > 0 {
+	if event.RequestedReviewer != nil && len(reviewers) > 0 {
 		requestedReviewer := *event.RequestedReviewer.Login
-		for _, reviewer := range reviewers {
-			if *reviewer.Login == requestedReviewer {
+		for _, prReviewer := range reviewers {
+			if *prReviewer.Login == requestedReviewer {
 				return false
 			}
 		}
 	}
-	info, response := p.getGitHubUserInfo(requestedUserID)
+	userInfo, response := p.getGitHubUserInfo(requestedUserID)
 	if response != nil {
 		p.client.Log.Warn("Failed to get stored userInfo", "error", response.Error())
 		return false
 	}
-	if info.Settings.DisableTeamNotifications {
+	if userInfo.Settings.DisableTeamNotifications {
 		return true
 	}
-	excluded := info.Settings.ExcludeTeamReviewNotifications
-	if len(excluded) == 0 {
+	excludedRepos := userInfo.Settings.ExcludeTeamReviewNotifications
+	if len(excludedRepos) == 0 {
 		return false
 	}
-	repoName := *event.Repo.FullName
-	for _, ex := range excluded {
-		if ex == repoName {
+	currentRepo := *event.Repo.FullName
+	for _, excludedRepo := range excludedRepos {
+		if excludedRepo == currentRepo {
 			return true
 		}
 	}

--- a/server/plugin/webhook_test.go
+++ b/server/plugin/webhook_test.go
@@ -1,0 +1,144 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/oauth2"
+
+	"github.com/mattermost/mattermost-plugin-github/server/mocks"
+	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
+)
+
+func TestIgnoreRequestedReview(t *testing.T) {
+	tests := map[string]struct {
+		event           *FPullRequestEvent
+		requestedUserID string
+		userInfo        *ForgejoUserInfo
+		expected        bool
+	}{
+		"empty user ID": {
+			event: &FPullRequestEvent{
+				PullRequest: &FPullRequest{
+					RequestedReviewersTeams: []*FTeam{},
+				},
+			},
+			requestedUserID: "",
+			expected:        false,
+		},
+		"no team reviewers": {
+			event: &FPullRequestEvent{
+				PullRequest: &FPullRequest{
+					RequestedReviewersTeams: []*FTeam{},
+				},
+			},
+			requestedUserID: "test-userID",
+			expected:        false,
+		},
+		"user is individual reviewer": {
+			event: &FPullRequestEvent{
+				PullRequest: &FPullRequest{
+					RequestedReviewersTeams: []*FTeam{{Name: stringPtr("team1")}},
+					RequestedReviewers: []*FUser{
+						{Login: stringPtr("test-user")},
+					},
+				},
+				RequestedReviewer: &FUser{Login: stringPtr("test-user")},
+			},
+			requestedUserID: "test-userID",
+			expected:        false,
+		},
+		"team notifications disabled": {
+			event: &FPullRequestEvent{
+				PullRequest: &FPullRequest{
+					RequestedReviewersTeams: []*FTeam{{Name: stringPtr("team1")}},
+				},
+			},
+			requestedUserID: "test-userID",
+			userInfo: &ForgejoUserInfo{
+				Token: &oauth2.Token{
+					AccessToken:  testToken,
+					RefreshToken: testToken,
+				},
+				Settings: &UserSettings{
+					DisableTeamNotifications: true,
+				},
+			},
+			expected: true,
+		},
+		"repository excluded": {
+			event: &FPullRequestEvent{
+				PullRequest: &FPullRequest{
+					RequestedReviewersTeams: []*FTeam{{Name: stringPtr("team1")}},
+				},
+				Repo: &FRepository{
+					FullName: stringPtr("org/repo1"),
+				},
+			},
+			requestedUserID: "test-userID",
+			userInfo: &ForgejoUserInfo{
+				Token: &oauth2.Token{
+					AccessToken:  testToken,
+					RefreshToken: testToken,
+				},
+				Settings: &UserSettings{
+					DisableTeamNotifications:       false,
+					ExcludeTeamReviewNotifications: []string{"org/repo1"},
+				},
+			},
+			expected: true,
+		},
+		"repository not excluded": {
+			event: &FPullRequestEvent{
+				PullRequest: &FPullRequest{
+					RequestedReviewersTeams: []*FTeam{{Name: stringPtr("team1")}},
+				},
+				Repo: &FRepository{
+					FullName: stringPtr("org/repo1"),
+				},
+			},
+			requestedUserID: "test-userID",
+			userInfo: &ForgejoUserInfo{
+				Token: &oauth2.Token{
+					AccessToken:  testToken,
+					RefreshToken: testToken,
+				},
+				Settings: &UserSettings{
+					DisableTeamNotifications:       false,
+					ExcludeTeamReviewNotifications: []string{"org/other-repo"},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			mockKvStore := mocks.NewMockKvStore(mockCtrl)
+			currentTestAPI := &plugintest.API{}
+			p := getPluginTest(currentTestAPI, mockKvStore)
+
+			// Mock getGitHubUserInfo if userInfo is provided
+			if tt.userInfo != nil {
+				mockKvStore.EXPECT().
+					Get("test-userID"+forgejoTokenKey, gomock.Any()).
+					DoAndReturn(func(key string, value interface{}) error {
+						*(value.(**ForgejoUserInfo)) = tt.userInfo
+						return nil
+					})
+			}
+
+			result := p.ignoreRequestedReview(tt.event, tt.requestedUserID)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// Helper function to create string pointers
+func stringPtr(s string) *string {
+	return &s
+}

--- a/server/plugin/webhook_test.go
+++ b/server/plugin/webhook_test.go
@@ -47,7 +47,16 @@ func TestIgnoreRequestedReview(t *testing.T) {
 				RequestedReviewer: &FUser{Login: stringPtr("test-user")},
 			},
 			requestedUserID: "test-userID",
-			expected:        false,
+			userInfo: &ForgejoUserInfo{
+				Token: &oauth2.Token{
+					AccessToken:  testToken,
+					RefreshToken: testToken,
+				},
+				Settings: &UserSettings{
+					DisableTeamNotifications: true,
+				},
+			},
+			expected: false,
 		},
 		"team notifications disabled": {
 			event: &FPullRequestEvent{
@@ -129,7 +138,8 @@ func TestIgnoreRequestedReview(t *testing.T) {
 					DoAndReturn(func(key string, value interface{}) error {
 						*(value.(**ForgejoUserInfo)) = tt.userInfo
 						return nil
-					})
+					}).
+					AnyTimes()
 			}
 
 			result := p.ignoreRequestedReview(tt.event, tt.requestedUserID)


### PR DESCRIPTION
Добавил пользователю возможность отключить уведомления о ревью, если оно назначено на команду
Можно отключить как для всех репозиториев, так и для конкретных
При этом если запрашивается помимо ревью команды еще и персональное, то уведомление придет в любом случае